### PR TITLE
bugfix/accurics_remediation_8652524516717673 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -11,6 +11,7 @@ resource google_sql_database_instance "master_instance" {
         name  = "WWW"
         value = "0.0.0.0/0"
       }
+      require_ssl = true
     }
     backup_configuration {
       enabled = false


### PR DESCRIPTION
**From Console:**

1. Go to [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).

2. Click on an instance name to see its configuration overview.

3. In the left-side panel, select `Connections`.

3. In the `SSL connections` section, click `Allow only SSL connections`.

4. Under `Configure SSL server certificates` click `Create new certificate`.

5. Under `Configure SSL client certificates` click `Create a client certificate`. 

6. Follow the instructions shown to learn how to connect to your instance. 

**From Command Line:**

To enforce SSL encryption for an instance run the command:

```
gcloud sql instances patch INSTANCE_NAME --require-ssl

```

Note:
`RESTART` is required for type MySQL Generation 1 Instances (`backendType: FIRST_GEN`) to get this configuration in effect.